### PR TITLE
Add example custom 404

### DIFF
--- a/src/theme/NotFound.js
+++ b/src/theme/NotFound.js
@@ -1,0 +1,46 @@
+import React, { useEffect } from 'react';
+import Translate, {translate} from '@docusaurus/Translate';
+import {PageMetadata} from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+export default function NotFound() {
+
+  return (
+    <>
+      <PageMetadata
+        title={translate({
+          id: 'theme.NotFound.title',
+          message: 'Page Not Found',
+        })}
+      />
+      <Layout>
+        <main className="container margin-vert--xl">
+          <div className="row">
+            <div className="col col--6 col--offset-3">
+              <h1 className="hero__title">
+                <Translate
+                  id="theme.NotFound.title"
+                  description="The title of the 404 page">
+                  404 TITLE
+                </Translate>
+              </h1>
+              <p>
+                <Translate
+                  id="theme.NotFound.p1"
+                  description="The first paragraph of the 404 page">
+                  404 SUMMARY
+                </Translate>
+              </p>
+              <p>
+                <Translate
+                  id="theme.NotFound.p2"
+                  description="The 2nd paragraph of the 404 page">
+                  404 FURTHER INFO.
+                </Translate>
+              </p>
+            </div>
+          </div>
+        </main>
+      </Layout>
+    </>
+  );
+}


### PR DESCRIPTION
With a little bit of help from this post here we can customize a 404 this way: https://github.com/facebook/docusaurus/discussions/6030#discussioncomment-6032674 

I believe just fill in the placeholders and it will work. 

If there are any problems with `npm start`, maybe try to double check:

* `npm run build`
* `npm run serve` 