### PR TITLE
Introduce Katex dependency for formulae

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,6 +3,8 @@
 
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
+const math = require('remark-math');
+const katex = require('rehype-katex');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -53,6 +55,8 @@ const config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           routeBasePath: '/',
+          remarkPlugins: [math],
+          rehypePlugins: [katex],
         },
         blog: false,
         // blog: {
@@ -67,6 +71,16 @@ const config = {
         },
       }),
     ],
+  ],
+
+  stylesheets: [
+    {
+        href: 'https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css',
+        type: 'text/css',
+        integrity:
+          'sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM',
+        crossorigin: 'anonymous',
+      },
   ],
 
   themeConfig:

--- a/package.json
+++ b/package.json
@@ -19,9 +19,12 @@
     "@docusaurus/preset-classic": "2.4.1",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
+    "hast-util-is-element": "^1.1.0",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "rehype-katex": "^5.0.0",
+    "remark-math": "^3.0.1"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.4.1"


### PR DESCRIPTION
Per README, I believe these changes are picked up just by running:

```sh
npm i
npm start
```

Via. https://docusaurus.io/docs/2.x/markdown-features/math-equations

E.g. 

![image](https://github.com/user-attachments/assets/0a91e2fd-5eed-4d22-9c1b-10afb6eed3ea)
