### PR TITLE
Add reference and link to the glossary

### DIFF
--- a/docs/glossary/_category_.json
+++ b/docs/glossary/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Glossary",
+    "position": 65535
+  }

--- a/docs/glossary/glossary.md
+++ b/docs/glossary/glossary.md
@@ -1,0 +1,13 @@
+---
+id: glossary
+sidebar_position: 0
+slug: /glossary
+pagination_prev: null
+---
+
+# Glossary
+
+The Orcfax glossary is hosted on [GitHub Pages][glossary-1] and provides the
+most technically accurate definitions of Orcfax domain components.
+
+[glossary-1]: https://glossary.orcfax.io/


### PR DESCRIPTION
This is the first place I'd still look as a dev and likely the first place for external users to look as well. I don't feel it especially important to host the Glossary here now, but maybe in future there can be another build step.